### PR TITLE
Investigate failed build in Scrapyard-Sites

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
 	"files": {
-		"ignore": ["**/.astro/**"]
+		"ignore": ["**/.astro/**", "dist/**"]
 	},
 	"formatter": { "enabled": true },
 	"linter": { "enabled": true },

--- a/package.json
+++ b/package.json
@@ -21,5 +21,6 @@
 		"tailwindcss": "^3.4.17",
 		"typescript": "^5.9.2",
 		"vitest": "^3.2.4"
-	}
+	},
+	"packageManager": "pnpm@9.15.9+sha512.68046141893c66fad01c079231128e9afb89ef87e2691d69e4d40eee228988295fd4682181bae55b58418c3a253bde65a505ec7c5f9403ece5cc3cd37dcf2531"
 }

--- a/src/__tests__/smoke.test.ts
+++ b/src/__tests__/smoke.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect } from "vitest"
+import { describe, expect, it } from "vitest"
 
 describe("smoke", () => {
-  it("sanity check", () => {
-    expect(1 + 1).toBe(2)
-  })
+	it("sanity check", () => {
+		expect(1 + 1).toBe(2)
+	})
 })


### PR DESCRIPTION
Fix CI build failure by applying Biome linting fixes to test files and ignoring the `dist` directory.

---
<a href="https://cursor.com/background-agent?bcId=bc-4c447dc8-9d69-4696-b387-86ba62efabc6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4c447dc8-9d69-4696-b387-86ba62efabc6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

