### PR TITLE
Check middleware content type formatting

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -28,10 +28,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
 
 	// Set proper content-type with charset for HTML responses
 	const contentType = response.headers.get("Content-Type")
-	if (
-		contentType?.includes("text/html") &&
-		!contentType.includes("charset")
-	) {
+	if (contentType?.includes("text/html") && !contentType.includes("charset")) {
 		response.headers.set("Content-Type", "text/html; charset=utf-8")
 	}
 


### PR DESCRIPTION
Fixes Biome formatting error in `src/middleware.ts` to pass lint checks.

---
<a href="https://cursor.com/background-agent?bcId=bc-dd53887e-cd01-4419-906b-9522424168d5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dd53887e-cd01-4419-906b-9522424168d5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

