### PR TITLE
Harmonize site margins based on device

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -55,8 +55,7 @@ import { withBase } from "../lib/paths"
   </section>
 
   <section class="band bg-brand-orange/5">
-    <div class="section">
-    <div class="container reveal-immediate">
+    <div class="section reveal-immediate">
       <div class="eyebrow">Reputation</div>
       <h2 class="mt-1 text-3xl font-bold tracking-tight">Your Website Is Your Digital Reputation</h2>
       <p class="mt-3 text-zinc-600">Before a single load hits your scale, sellers decide if they trust you—based in large part on what they see online.</p>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -22,13 +22,13 @@
 		@apply mx-auto max-w-7xl px-6 md:px-8;
 	}
 	.container-narrow {
-		@apply mx-auto max-w-3xl px-4 md:px-6;
+		@apply mx-auto max-w-3xl px-6 md:px-8;
 	}
 	.section {
 		@apply mx-auto max-w-7xl px-6 md:px-8 py-12 md:py-16;
 	}
 	.section-narrow {
-		@apply mx-auto max-w-3xl px-4 md:px-6 py-8 md:py-12;
+		@apply mx-auto max-w-3xl px-6 md:px-8 py-8 md:py-12;
 	}
 	.anchor-target {
 		scroll-margin-top: 6rem;


### PR DESCRIPTION
Harmonize site-wide horizontal margins by standardizing padding classes and removing redundant nesting.

The site's horizontal margins now consistently match the Hero section's `px-6` (24px) on mobile and the Reputation section's `px-8` (32px) on desktop, achieved by updating `container-narrow` and `section-narrow` classes and resolving a double-padding issue in the Reputation section.

---
<a href="https://cursor.com/background-agent?bcId=bc-95e0825d-3b5b-454c-ab6c-64344e8a5c38">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-95e0825d-3b5b-454c-ab6c-64344e8a5c38">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

