### PR TITLE
Fix mobile contact and home page layouts

### DIFF
--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -14,7 +14,7 @@ import Base from "../layouts/Base.astro"
       <div class="container-narrow text-center">
         <h1 class="text-3xl font-bold tracking-tight">Schedule Your 15-Minute Call</h1>
         <p class="mt-3 text-zinc-700">Call <a href="tel:19493568762" class="link font-medium">949‑356‑8762</a> or use the form below.</p>
-        <ul class="mt-4 flex flex-wrap items-center justify-center gap-4 text-sm text-zinc-600">
+        <ul class="mt-4 flex flex-nowrap items-center justify-center gap-4 text-sm text-zinc-600">
           <li class="inline-flex items-center gap-2"><Check class="h-4 w-4 text-brand-orange" /> <span>No spam</span></li>
           <li class="inline-flex items-center gap-2"><Shield class="h-4 w-4 text-brand-orange" /> <span>Confidential</span></li>
           <li class="inline-flex items-center gap-2"><Clock class="h-4 w-4 text-brand-orange" /> <span>15 minutes max</span></li>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -143,13 +143,13 @@ import { withBase } from "../lib/paths"
       <div>
         <h2 class="text-2xl font-bold tracking-tight">Protect Your Name</h2>
         <p class="mt-3 text-zinc-700">Reputation is everything. Don’t let an outdated or nonexistent site put yours at risk. Fill the form below or call <a href="tel:19493568762" class="text-brand-orange font-medium">949‑356‑8762</a> to see how much credibility a modern website can add.</p>
-        <ul class="mt-4 flex flex-wrap items-center gap-4 text-sm text-zinc-600">
+        <ul class="mt-4 flex flex-nowrap items-center gap-4 text-sm text-zinc-600">
           <li class="inline-flex items-center gap-2"><Check class="h-4 w-4 text-brand-orange" /> <span>No spam</span></li>
           <li class="inline-flex items-center gap-2"><Shield class="h-4 w-4 text-brand-orange" /> <span>Confidential</span></li>
           <li class="inline-flex items-center gap-2"><Clock class="h-4 w-4 text-brand-orange" /> <span>15 minutes max</span></li>
         </ul>
       </div>
-      <div class="max-w-3xl mx-auto lg:max-w-none">
+      <div>
         <ContactForm />
       </div>
     </div>


### PR DESCRIPTION
Fixes mobile layout for contact and home pages by ensuring single-line feature items and consistent form input width.

The home page contact form's input width was too small due to an unnecessary `max-w-3xl mx-auto lg:max-w-none` wrapper, which was removed. The feature list items on both pages were changed from `flex-wrap` to `flex-nowrap` to prevent them from breaking into multiple lines on mobile.

---
<a href="https://cursor.com/background-agent?bcId=bc-832c04b9-f247-4113-826a-bb912153b7ac">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-832c04b9-f247-4113-826a-bb912153b7ac">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

