### PR TITLE
Apply about page margins to mobile sections

### DIFF
--- a/src/components/BetaInvite.astro
+++ b/src/components/BetaInvite.astro
@@ -2,7 +2,7 @@
 import { withBase } from "../lib/paths"
 ---
 <section class="mt-16">
-  <div class="container">
+  <div class="container px-4 sm:px-6 md:px-12">
     <div class="rounded-lg bg-brand-orange text-white p-6 sm:p-8">
       <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>

--- a/src/components/DepositBanner.astro
+++ b/src/components/DepositBanner.astro
@@ -10,7 +10,7 @@ const {
 } = Astro.props as Props
 ---
 <section class="mt-16">
-  <div class="container">
+  <div class="container px-4 sm:px-6 md:px-12">
     <div class="rounded-lg bg-brand-orange text-white p-6 sm:p-8">
       <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -3,7 +3,7 @@ import Base from "../layouts/Base.astro"
 import { withBase } from "../lib/paths"
 ---
 <Base title="Page not found — Scrapyard Sites">
-  <section class="container-narrow px-6 py-24 text-center">
+  <section class="container-narrow px-4 sm:px-6 py-24 text-center">
     <h1 class="text-4xl font-bold tracking-tight">404 — Page not found</h1>
     <p class="mt-3 text-zinc-600">The page you’re looking for doesn’t exist or has moved.</p>
     <a class="mt-6 inline-block link" href={withBase('/')}>Go home →</a>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -14,7 +14,7 @@ import { withBase } from "../lib/paths"
 
   <section class="band bg-brand-orange/5">
     <div class="section">
-    <div class="mt-6 reveal-immediate px-4 sm:px-6 lg:px-8">
+    <div class="mt-6 reveal-immediate">
       <!-- Mobile: Title first, then image and content -->
       <div class="lg:hidden">
         <h2 class="text-2xl font-bold tracking-tight mb-6">My Insider Edge</h2>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -6,7 +6,7 @@ import { withBase } from "../../lib/paths"
   <Fragment slot="head">
     <meta name="description" content="Articles on credibility, qualification, visibility, and reliability for scrap yard owners." />
   </Fragment>
-  <section class="container py-16">
+  <section class="container px-4 sm:px-6 md:px-12 py-16">
     <div class="eyebrow">Blog</div>
     <h1 class="mt-1 text-3xl font-bold tracking-tight">Reputation & Growth Insights</h1>
     <p class="mt-3 max-w-2xl text-zinc-700">Practical articles on credibility, lead qualification, local visibility and operational reliability—written specifically for scrap yard owners.</p>

--- a/src/pages/blog/posts/care-plan-essentials.astro
+++ b/src/pages/blog/posts/care-plan-essentials.astro
@@ -14,7 +14,7 @@ import { withBase } from "../../../lib/paths"
       mainEntityOfPage: { '@type': 'WebPage', '@id': Astro.url.href }
     })}</script>
   </Fragment>
-  <main class="container-narrow py-16">
+  <main class="container-narrow px-4 sm:px-6 md:px-12 py-16">
     <a href={withBase('/blog/')} class="link">← Back to blog</a>
     <div class="mt-6 text-xs font-semibold uppercase text-zinc-500">Reliability</div>
     <h1 class="mt-1 text-3xl font-bold tracking-tight">Care Plan Essentials</h1>

--- a/src/pages/blog/posts/pre-qualify-scrap-sellers.astro
+++ b/src/pages/blog/posts/pre-qualify-scrap-sellers.astro
@@ -14,7 +14,7 @@ import { withBase } from "../../../lib/paths"
       mainEntityOfPage: { '@type': 'WebPage', '@id': Astro.url.href }
     })}</script>
   </Fragment>
-  <main class="container-narrow py-16">
+  <main class="container-narrow px-4 sm:px-6 md:px-12 py-16">
     <a href={withBase('/blog/')} class="link">← Back to blog</a>
     <div class="mt-6 text-xs font-semibold uppercase text-zinc-500">Qualification</div>
     <h1 class="mt-1 text-3xl font-bold tracking-tight">Pre‑Qualify Scrap Sellers</h1>

--- a/src/pages/blog/posts/seo-basics-for-scrap-yards.astro
+++ b/src/pages/blog/posts/seo-basics-for-scrap-yards.astro
@@ -14,7 +14,7 @@ import { withBase } from "../../../lib/paths"
       mainEntityOfPage: { '@type': 'WebPage', '@id': Astro.url.href }
     })}</script>
   </Fragment>
-  <main class="container-narrow py-16">
+  <main class="container-narrow px-4 sm:px-6 md:px-12 py-16">
     <a href={withBase('/blog/')} class="link">← Back to blog</a>
     <div class="mt-6 text-xs font-semibold uppercase text-zinc-500">Visibility</div>
     <h1 class="mt-1 text-3xl font-bold tracking-tight">SEO Basics for Scrap Yards</h1>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -25,7 +25,7 @@ import { withBase } from "../lib/paths"
   />
 
   <section class="band border-y border-zinc-200 bg-white">
-    <div class="container py-3">
+    <div class="container px-4 sm:px-6 md:px-12 py-3">
       <!-- Desktop/tablet layout - shows as flex items, switches to marquee when wrapped -->
       <ul id="features-list" class="hidden sm:flex flex-wrap items-center justify-center gap-x-6 gap-y-2 text-sm text-zinc-700">
         <li class="inline-flex items-center gap-2"><Shield class="h-4 w-4 text-brand-orange" /> <span>Industry experience in yards & metals</span></li>

--- a/src/pages/privacy/index.astro
+++ b/src/pages/privacy/index.astro
@@ -5,7 +5,7 @@ import Base from "../../layouts/Base.astro"
   <Fragment slot="head">
     <meta name="description" content="Learn how Scrapyard Sites collects, uses, and protects your information." />
   </Fragment>
-  <main class="container-narrow py-16">
+  <main class="container-narrow px-4 sm:px-6 md:px-12 py-16">
     <h1 class="text-3xl font-bold tracking-tight">Privacy Policy</h1>
     <p class="mt-4 text-sm text-zinc-700">Effective Date: January 1, 2024</p>
     <section class="mt-6 prose prose-zinc max-w-none">

--- a/src/pages/terms-of-service.astro
+++ b/src/pages/terms-of-service.astro
@@ -6,7 +6,7 @@ import { withBase } from "../lib/paths"
   <Fragment slot="head">
     <meta name="description" content="Terms governing the use of Scrapyard Sites services." />
   </Fragment>
-  <section class="container-narrow py-16">
+  <section class="container-narrow px-4 sm:px-6 md:px-12 py-16">
     <h1 class="text-3xl font-bold tracking-tight">Terms of Service</h1>
     <section class="mt-6 prose prose-zinc max-w-none">
       <h2>Agreement</h2>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -25,10 +25,10 @@
 		@apply mx-auto max-w-3xl px-6 md:px-12;
 	}
 	.section {
-		@apply mx-auto max-w-7xl px-6 md:px-12 py-12 md:py-16;
+		@apply mx-auto max-w-7xl px-4 sm:px-6 md:px-12 py-12 md:py-16;
 	}
 	.section-narrow {
-		@apply mx-auto max-w-3xl px-6 md:px-12 py-8 md:py-12;
+		@apply mx-auto max-w-3xl px-4 sm:px-6 md:px-12 py-8 md:py-12;
 	}
 	.anchor-target {
 		scroll-margin-top: 6rem;


### PR DESCRIPTION
Standardize mobile horizontal margins across content sections to match the About page's `px-4` padding.

---
<a href="https://cursor.com/background-agent?bcId=bc-bf6b80d9-352a-4377-9bfc-533c0d69cd78">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bf6b80d9-352a-4377-9bfc-533c0d69cd78">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

