### PR TITLE
Check mobile contact page padding

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -25,14 +25,14 @@
 		@apply mx-auto max-w-3xl px-6 md:px-12;
 	}
 	.section {
-		@apply mx-auto max-w-7xl px-4 sm:px-6 md:px-12 py-12 md:py-16;
+		@apply mx-auto max-w-7xl px-6 sm:px-6 md:px-12 py-12 md:py-16;
 	}
 	.section-narrow {
-		@apply mx-auto max-w-3xl px-4 sm:px-6 md:px-12 py-8 md:py-12;
+		@apply mx-auto max-w-3xl px-6 sm:px-6 md:px-12 py-8 md:py-12;
 	}
-	/* Mobile section padding - matches the Contact page "Schedule your 15 minute call" section */
+	/* Mobile section padding - standardized 24px horizontal padding from viewport edges */
 	.mobile-section-padding {
-		@apply px-4 sm:px-6 md:px-12;
+		@apply px-6 sm:px-6 md:px-12;
 	}
 	.anchor-target {
 		scroll-margin-top: 6rem;


### PR DESCRIPTION
Standardize mobile horizontal padding for all main content sections to 24px.

This change ensures a consistent 24px horizontal padding from the viewport edges on mobile devices for `.section`, `.section-narrow`, and `.mobile-section-padding` classes, aligning them with the desired site-wide standard.

---
<a href="https://cursor.com/background-agent?bcId=bc-6807297c-beaf-404e-be6f-da4468c32687">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6807297c-beaf-404e-be6f-da4468c32687">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

