### PR TITLE
Investigate mobile px-6 horizontal padding issue

### DIFF
--- a/src/components/BetaInvite.astro
+++ b/src/components/BetaInvite.astro
@@ -2,7 +2,7 @@
 import { withBase } from "../lib/paths"
 ---
 <section class="mt-16">
-  <div class="container mobile-section-padding">
+  <div class="container">
     <div class="rounded-lg bg-brand-orange text-white p-6 sm:p-8">
       <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>

--- a/src/components/DepositBanner.astro
+++ b/src/components/DepositBanner.astro
@@ -10,7 +10,7 @@ const {
 } = Astro.props as Props
 ---
 <section class="mt-16">
-  <div class="container mobile-section-padding">
+  <div class="container">
     <div class="rounded-lg bg-brand-orange text-white p-6 sm:p-8">
       <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -6,7 +6,7 @@ import { withBase } from "../../lib/paths"
   <Fragment slot="head">
     <meta name="description" content="Articles on credibility, qualification, visibility, and reliability for scrap yard owners." />
   </Fragment>
-  <section class="container mobile-section-padding py-16">
+  <section class="container py-16">
     <div class="eyebrow">Blog</div>
     <h1 class="mt-1 text-3xl font-bold tracking-tight">Reputation & Growth Insights</h1>
     <p class="mt-3 max-w-2xl text-zinc-700">Practical articles on credibility, lead qualification, local visibility and operational reliability—written specifically for scrap yard owners.</p>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -25,7 +25,7 @@ import { withBase } from "../lib/paths"
   />
 
   <section class="band border-y border-zinc-200 bg-white">
-    <div class="container mobile-section-padding py-3">
+    <div class="container py-3">
       <!-- Desktop/tablet layout - shows as flex items, switches to marquee when wrapped -->
       <ul id="features-list" class="hidden sm:flex flex-wrap items-center justify-center gap-x-6 gap-y-2 text-sm text-zinc-700">
         <li class="inline-flex items-center gap-2"><Shield class="h-4 w-4 text-brand-orange" /> <span>Industry experience in yards & metals</span></li>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -25,14 +25,15 @@
 		@apply mx-auto max-w-3xl px-6 md:px-12;
 	}
 	.section {
-		@apply mx-auto max-w-7xl px-6 sm:px-6 md:px-12 py-12 md:py-16;
+		@apply mx-auto max-w-7xl px-6 md:px-12 py-12 md:py-16;
 	}
 	.section-narrow {
-		@apply mx-auto max-w-3xl px-6 sm:px-6 md:px-12 py-8 md:py-12;
+		@apply mx-auto max-w-3xl px-6 md:px-12 py-8 md:py-12;
 	}
 	/* Mobile section padding - standardized 24px horizontal padding from viewport edges */
+	/* Note: Do not use with .container class as it already includes padding */
 	.mobile-section-padding {
-		@apply px-6 sm:px-6 md:px-12;
+		@apply px-6 md:px-12;
 	}
 	.anchor-target {
 		scroll-margin-top: 6rem;


### PR DESCRIPTION
Fixes `px-6` mobile padding by removing redundant `sm:px-6` declarations and resolving conflicts between `.container` and `.mobile-section-padding` classes.

The `px-6` padding was not applying correctly on mobile due to two main issues:
1.  Redundant `sm:px-6` declarations in `globals.css` for `.section`, `.section-narrow`, and `.mobile-section-padding` classes, as `px-6` already applies to all screen sizes.
2.  Conflicting `px-6` applications when `.container` and `.mobile-section-padding` were used together, as both classes applied the same padding. This PR removes the redundant `sm:px-6` and the `.mobile-section-padding` class from elements already using `.container`.

---
<a href="https://cursor.com/background-agent?bcId=bc-6f4e5ebd-8882-4a0b-bfdf-ae314988e29a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6f4e5ebd-8882-4a0b-bfdf-ae314988e29a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

