### PR TITLE
Investigate px-6 padding on mobile

### DIFF
--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -28,9 +28,7 @@ import Base from "../layouts/Base.astro"
     </div>
   </section>
   <section class="band bg-white">
-    <div class="reveal">
-      <FAQ items={DEFAULT_FAQ} tinted />
-    </div>
+    <FAQ items={DEFAULT_FAQ} tinted />
   </section>
   
 </Base>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -157,9 +157,7 @@ import { withBase } from "../lib/paths"
   </section>
 
   <section class="band">
-    <div class="reveal">
-      <FAQ items={DEFAULT_FAQ} tinted />
-    </div>
+    <FAQ items={DEFAULT_FAQ} tinted />
   </section>
 
   

--- a/src/pages/pricing.astro
+++ b/src/pages/pricing.astro
@@ -15,10 +15,8 @@ import { withBase } from "../lib/paths"
   />
 
   <section class="band bg-brand-orange/5" id="packages">
-    <div class="pt-0 pb-0">
-      <div class="reveal-immediate">
-        <PricingTable heading="Service Pricing" showDepositCta={true} depositGoal="CTA: Pay Deposit (Pricing)" />
-      </div>
+    <div class="reveal-immediate">
+      <PricingTable heading="Service Pricing" showDepositCta={true} depositGoal="CTA: Pay Deposit (Pricing)" />
     </div>
   </section>
 
@@ -51,9 +49,7 @@ import { withBase } from "../lib/paths"
   </section>
 
   <section class="band bg-brand-orange/5">
-    <div class="reveal">
-      <FAQ items={DEFAULT_FAQ} />
-    </div>
+    <FAQ items={DEFAULT_FAQ} />
   </section>
 </Base>
 


### PR DESCRIPTION
Removes redundant wrapper divs to ensure consistent `px-6` horizontal padding on mobile.

Some components, like `FAQ` and `PricingTable`, already include the `.section` class (which provides `px-6` padding). They were incorrectly wrapped in `div`s that lacked horizontal padding, causing the mobile padding to be absent on affected pages. This change removes those unnecessary wrappers, allowing the components' inherent padding to apply correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-f12fcbcf-5e41-4bd6-a72e-901ac2e5ace3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f12fcbcf-5e41-4bd6-a72e-901ac2e5ace3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

