### PR TITLE
Fix mobile horizontal padding for page elements

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -3,7 +3,7 @@ import Base from "../layouts/Base.astro"
 import { withBase } from "../lib/paths"
 ---
 <Base title="Page not found — Scrapyard Sites">
-  <section class="container-narrow mobile-section-padding py-24 text-center">
+  <section class="container-narrow py-24 text-center">
     <h1 class="text-4xl font-bold tracking-tight">404 — Page not found</h1>
     <p class="mt-3 text-zinc-600">The page you’re looking for doesn’t exist or has moved.</p>
     <a class="mt-6 inline-block link" href={withBase('/')}>Go home →</a>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -55,7 +55,6 @@ import { withBase } from "../lib/paths"
         </div>
       </div>
     </div>
-    </div>
   </section>
   
 </Base>

--- a/src/pages/blog/posts/care-plan-essentials.astro
+++ b/src/pages/blog/posts/care-plan-essentials.astro
@@ -14,7 +14,7 @@ import { withBase } from "../../../lib/paths"
       mainEntityOfPage: { '@type': 'WebPage', '@id': Astro.url.href }
     })}</script>
   </Fragment>
-  <main class="container-narrow mobile-section-padding py-16">
+  <main class="container-narrow py-16">
     <a href={withBase('/blog/')} class="link">← Back to blog</a>
     <div class="mt-6 text-xs font-semibold uppercase text-zinc-500">Reliability</div>
     <h1 class="mt-1 text-3xl font-bold tracking-tight">Care Plan Essentials</h1>

--- a/src/pages/blog/posts/pre-qualify-scrap-sellers.astro
+++ b/src/pages/blog/posts/pre-qualify-scrap-sellers.astro
@@ -14,7 +14,7 @@ import { withBase } from "../../../lib/paths"
       mainEntityOfPage: { '@type': 'WebPage', '@id': Astro.url.href }
     })}</script>
   </Fragment>
-  <main class="container-narrow mobile-section-padding py-16">
+  <main class="container-narrow py-16">
     <a href={withBase('/blog/')} class="link">← Back to blog</a>
     <div class="mt-6 text-xs font-semibold uppercase text-zinc-500">Qualification</div>
     <h1 class="mt-1 text-3xl font-bold tracking-tight">Pre‑Qualify Scrap Sellers</h1>

--- a/src/pages/blog/posts/seo-basics-for-scrap-yards.astro
+++ b/src/pages/blog/posts/seo-basics-for-scrap-yards.astro
@@ -14,7 +14,7 @@ import { withBase } from "../../../lib/paths"
       mainEntityOfPage: { '@type': 'WebPage', '@id': Astro.url.href }
     })}</script>
   </Fragment>
-  <main class="container-narrow mobile-section-padding py-16">
+  <main class="container-narrow py-16">
     <a href={withBase('/blog/')} class="link">← Back to blog</a>
     <div class="mt-6 text-xs font-semibold uppercase text-zinc-500">Visibility</div>
     <h1 class="mt-1 text-3xl font-bold tracking-tight">SEO Basics for Scrap Yards</h1>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -100,7 +100,6 @@ import { withBase } from "../lib/paths"
         </a>
       </div>
     </div>
-    </div>
   </section>
 
   
@@ -132,7 +131,6 @@ import { withBase } from "../lib/paths"
         <p class="mt-2 text-sm text-zinc-600">We go live, check call/form flow, and adjust in week 1.</p>
       </Card>
     </div>
-    </div>
   </section>
 
   
@@ -153,8 +151,6 @@ import { withBase } from "../lib/paths"
         <ContactForm />
       </div>
     </div>
-    </div>
-  </section>
 
   <section class="band">
     <FAQ items={DEFAULT_FAQ} tinted />

--- a/src/pages/pricing.astro
+++ b/src/pages/pricing.astro
@@ -15,9 +15,7 @@ import { withBase } from "../lib/paths"
   />
 
   <section class="band bg-brand-orange/5" id="packages">
-    <div class="reveal-immediate">
       <PricingTable heading="Service Pricing" showDepositCta={true} depositGoal="CTA: Pay Deposit (Pricing)" />
-    </div>
   </section>
 
   <section class="band">
@@ -43,7 +41,6 @@ import { withBase } from "../lib/paths"
          <li><a href={withBase('/contact/')} class="link">Contact us</a></li>
         </ul>
       </div>
-    </div>
     </div>
     </div>
   </section>

--- a/src/pages/privacy/index.astro
+++ b/src/pages/privacy/index.astro
@@ -5,7 +5,7 @@ import Base from "../../layouts/Base.astro"
   <Fragment slot="head">
     <meta name="description" content="Learn how Scrapyard Sites collects, uses, and protects your information." />
   </Fragment>
-  <main class="container-narrow mobile-section-padding py-16">
+  <main class="container-narrow py-16">
     <h1 class="text-3xl font-bold tracking-tight">Privacy Policy</h1>
     <p class="mt-4 text-sm text-zinc-700">Effective Date: January 1, 2024</p>
     <section class="mt-6 prose prose-zinc max-w-none">

--- a/src/pages/services.astro
+++ b/src/pages/services.astro
@@ -71,7 +71,6 @@ import { withBase } from "../lib/paths"
       </div>
           </div>
     </div>
-    </div>
   </section>
   
 </Base>

--- a/src/pages/terms-of-service.astro
+++ b/src/pages/terms-of-service.astro
@@ -6,7 +6,7 @@ import { withBase } from "../lib/paths"
   <Fragment slot="head">
     <meta name="description" content="Terms governing the use of Scrapyard Sites services." />
   </Fragment>
-  <section class="container-narrow mobile-section-padding py-16">
+  <section class="container-narrow py-16">
     <h1 class="text-3xl font-bold tracking-tight">Terms of Service</h1>
     <section class="mt-6 prose prose-zinc max-w-none">
       <h2>Agreement</h2>


### PR DESCRIPTION
Fixes inconsistent 24px mobile horizontal padding across pages.

The issue stemmed from malformed HTML with extra closing `</div>` tags preventing correct padding application, and redundant `px-6` padding classes (`container-narrow` and `mobile-section-padding`) causing double padding on certain pages.

---
<a href="https://cursor.com/background-agent?bcId=bc-0dabddf4-7532-48fe-a16c-35f06d791cc6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0dabddf4-7532-48fe-a16c-35f06d791cc6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

