### PR TITLE
Fix mobile horizontal padding on page elements

### DIFF
--- a/src/components/FAQ.astro
+++ b/src/components/FAQ.astro
@@ -19,7 +19,7 @@ const detailsClass = tinted
 	? "faq-details group rounded-md border border-brand-orange/20 bg-brand-orange/5 p-4 faq-tinted transition-all duration-300"
 	: "faq-details group rounded-md border border-zinc-200 bg-white p-4 faq-default transition-all duration-300"
 ---
-<section class={sectionClass} itemscope itemtype="https://schema.org/FAQPage">
+<div class={sectionClass} itemscope itemtype="https://schema.org/FAQPage">
   <h2 class="mt-1 text-2xl font-bold tracking-tight">{heading}</h2>
   <div class="mt-4 space-y-2">
     {items.map((it) => (
@@ -38,7 +38,7 @@ const detailsClass = tinted
       </details>
     ))}
   </div>
-</section>
+</div>
 
 <script>
   document.addEventListener('DOMContentLoaded', function() {

--- a/src/components/PricingTable.astro
+++ b/src/components/PricingTable.astro
@@ -15,7 +15,7 @@ const {
 	tinted = false,
 } = Astro.props as Props
 ---
-<section class="section">
+<div class="section">
   <div class="eyebrow">Pricing</div>
   <h2 class="mt-1 text-2xl font-bold tracking-tight">{heading}</h2>
   <div class="mt-6 grid gap-6 md:grid-cols-2">
@@ -43,6 +43,6 @@ const {
     </div>
   )}
   
-</section>
+</div>
 
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -131,6 +131,7 @@ import { withBase } from "../lib/paths"
         <p class="mt-2 text-sm text-zinc-600">We go live, check call/form flow, and adjust in week 1.</p>
       </Card>
     </div>
+    </div>
   </section>
 
   
@@ -151,6 +152,8 @@ import { withBase } from "../lib/paths"
         <ContactForm />
       </div>
     </div>
+    </div>
+  </section>
 
   <section class="band">
     <FAQ items={DEFAULT_FAQ} tinted />


### PR DESCRIPTION
Refactor component structure to ensure consistent 24px mobile horizontal padding across all pages.

The issue stemmed from components like `PricingTable` and `FAQ` applying the `.section` class (which provides padding) directly to their root `<section>` element. When these components were then wrapped in `.band` containers, the padding was not applied correctly. The fix involves changing the root of these components to a `<div>` with the `.section` class, ensuring the padding is always applied by an inner `div` within a `.band` container, matching the correct pattern observed on the contact page. Structural HTML fixes were also applied in `index.astro` to support this consistent padding.

---
<a href="https://cursor.com/background-agent?bcId=bc-c7817e2f-4344-4216-9bdb-5678b3913794">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c7817e2f-4344-4216-9bdb-5678b3913794">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

