### PR TITLE
Fix mobile horizontal padding for page elements

### DIFF
--- a/src/pages/terms-of-service.astro
+++ b/src/pages/terms-of-service.astro
@@ -6,29 +6,30 @@ import { withBase } from "../lib/paths"
   <Fragment slot="head">
     <meta name="description" content="Terms governing the use of Scrapyard Sites services." />
   </Fragment>
-  <section class="container-narrow py-16">
-    <h1 class="text-3xl font-bold tracking-tight">Terms of Service</h1>
-    <section class="mt-6 prose prose-zinc max-w-none">
-      <h2>Agreement</h2>
-      <p>By using our services, you agree to these terms.</p>
-      <h2>Services</h2>
-      <p>We provide website design, development, and maintenance for scrapyards per the plan you select.</p>
-      <h2>Payments</h2>
-      <ul>
-        <li>50% deposit to reserve build week; balance due at launch.</li>
-        <li>Care plan billed monthly; cancel anytime with 30 days’ notice.</li>
-      </ul>
-      <h2>Content & Ownership</h2>
-      <p>You own your content, domain, and assets. We grant you a license to any custom code provided.</p>
-      <h2>Warranties & Liability</h2>
-      <p>Services are provided “as is”. We’re not liable for indirect or consequential damages.</p>
-      <h2>Privacy</h2>
-      <p>See our <a href={withBase('/privacy/')}>Privacy Policy</a> for details on data handling.</p>
-      <h2>Changes</h2>
-      <p>We may update these terms; changes will be posted with an updated effective date.</p>
-      <h2>Contact</h2>
-      <p>Email: <a href="mailto:hello@scrapyardsites.com">hello@scrapyardsites.com</a> | Phone: <a href="tel:19493568762">949‑356‑8762</a></p>
-    </section>
+  <section class="band">
+    <div class="section">
+      <h1 class="text-3xl font-bold tracking-tight">Terms of Service</h1>
+      <section class="mt-6 prose prose-zinc max-w-none">
+        <h2>Agreement</h2>
+        <p>By using our services, you agree to these terms.</p>
+        <h2>Services</h2>
+        <p>We provide website design, development, and maintenance for scrapyards per the plan you select.</p>
+        <h2>Payments</h2>
+        <ul>
+          <li>50% deposit to reserve build week; balance due at launch.</li>
+          <li>Care plan billed monthly; cancel anytime with 30 days' notice.</li>
+        </ul>
+        <h2>Content & Ownership</h2>
+        <p>You own your content, domain, and assets. We grant you a license to any custom code provided.</p>
+        <h2>Warranties & Liability</h2>
+        <p>Services are provided "as is". We're not liable for indirect or consequential damages.</p>
+        <h2>Privacy</h2>
+        <p>See our <a href={withBase('/privacy/')}>Privacy Policy</a> for details on data handling.</p>
+        <h2>Changes</h2>
+        <p>We may update these terms; changes will be posted with an updated effective date.</p>
+        <h2>Contact</h2>
+        <p>Email: <a href="mailto:hello@scrapyardsites.com">hello@scrapyardsites.com</a> | Phone: <a href="tel:19493568762">949‑356‑8762</a></p>
+      </section>
+    </div>
   </section>
 </Base>
-


### PR DESCRIPTION
Standardize horizontal padding across pages to match the contact page's 48px mobile padding.

The contact page's top section had double horizontal padding (48px on mobile) due to nested container classes, which the user perceived as the correct padding. This PR updates other pages to replicate this structure, ensuring consistent 48px horizontal padding on mobile for content sections.

---
<a href="https://cursor.com/background-agent?bcId=bc-d99b96e5-ae01-47e4-bbf7-ad5baf97ec6c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d99b96e5-ae01-47e4-bbf7-ad5baf97ec6c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

