### PR TITLE
Fix mobile horizontal padding inconsistencies

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -15,7 +15,7 @@ import { withBase } from "../lib/paths"
   <section class="band bg-brand-orange/5">
     <div class="section">
       <div class="mt-6 reveal-immediate">
-        <div class="container-narrow">
+        <div class="content-narrow">
           <!-- Mobile: Title first, then image and content -->
           <div class="lg:hidden">
         <h2 class="text-2xl font-bold tracking-tight mb-6">My Insider Edge</h2>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -11,7 +11,7 @@ import Base from "../layouts/Base.astro"
   <section class="band bg-brand-orange/5">
     <div class="section">
     <div class="reveal-immediate">
-      <div class="container-narrow text-center">
+      <div class="content-narrow text-center">
         <h1 class="text-3xl font-bold tracking-tight">Schedule Your 15-Minute Call</h1>
         <p class="mt-3 text-zinc-700">Call <a href="tel:19493568762" class="link font-medium">949‑356‑8762</a> or use the form below.</p>
         <ul class="mt-4 flex flex-nowrap items-center justify-center gap-4 text-sm text-zinc-600">
@@ -20,7 +20,7 @@ import Base from "../layouts/Base.astro"
           <li class="inline-flex items-center gap-2"><Clock class="h-4 w-4 text-brand-orange" /> <span>15 minutes max</span></li>
         </ul>
       </div>
-      <div class="container-narrow mt-8">
+      <div class="content-narrow mt-8">
         <ContactForm submitLabel="Schedule my 15-minute call" goal="Form: Submit (Contact)" />
         
       </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -57,7 +57,7 @@ import { withBase } from "../lib/paths"
   <section class="band bg-brand-orange/5">
     <div class="section">
       <div class="reveal-immediate">
-        <div class="container-narrow">
+        <div class="content-narrow">
           <div class="eyebrow">Reputation</div>
           <h2 class="mt-1 text-3xl font-bold tracking-tight">Your Website Is Your Digital Reputation</h2>
           <p class="mt-3 text-zinc-600">Before a single load hits your scale, sellers decide if they trust you—based in large part on what they see online.</p>
@@ -111,7 +111,7 @@ import { withBase } from "../lib/paths"
   <section class="band bg-white">
     <div class="section">
       <div class="reveal">
-        <div class="container-narrow">
+        <div class="content-narrow">
           <div class="eyebrow">How it works</div>
           <h2 class="mt-1 text-2xl font-bold tracking-tight">Three Simple Steps</h2>
     <div class="mt-6 grid gap-6 sm:grid-cols-3">
@@ -147,7 +147,7 @@ import { withBase } from "../lib/paths"
   <section class="band bg-brand-orange/5" id="contact">
     <div class="section">
       <div class="reveal">
-        <div class="container-narrow">
+        <div class="content-narrow">
           <div class="mt-1 grid gap-8 lg:grid-cols-2">
       <div>
         <h2 class="text-2xl font-bold tracking-tight">Protect Your Name</h2>

--- a/src/pages/pricing.astro
+++ b/src/pages/pricing.astro
@@ -21,7 +21,7 @@ import { withBase } from "../lib/paths"
   <section class="band">
     <div class="section">
       <div class="reveal">
-        <div class="container-narrow">
+        <div class="content-narrow">
           <div class="eyebrow">Details</div>
     <h2 class="mt-1 text-2xl font-bold tracking-tight">How It Works & Extras</h2>
     <div class="mt-4 grid gap-6 lg:grid-cols-2">

--- a/src/pages/process.astro
+++ b/src/pages/process.astro
@@ -18,7 +18,7 @@ import { withBase } from "../lib/paths"
   <section class="band bg-brand-orange/5" id="credibility">
     <div class="section">
       <div class="reveal-immediate">
-        <div class="container-narrow">
+        <div class="content-narrow">
           <div class="eyebrow">Process</div>
         <h2 class="mt-1 text-2xl font-bold tracking-tight">Our Process</h2>
         <div class="mt-6 grid gap-6 sm:grid-cols-2 lg:grid-cols-4">

--- a/src/pages/services.astro
+++ b/src/pages/services.astro
@@ -19,7 +19,7 @@ import { withBase } from "../lib/paths"
   <section class="band bg-brand-orange/5">
     <div class="section">
       <div class="reveal-immediate">
-        <div class="container-narrow">
+        <div class="content-narrow">
           <div class="eyebrow">Services</div>
         <h2 class="mt-1 text-2xl font-bold tracking-tight">Four Pillars</h2>
         <p class="mt-3 text-zinc-700">We focus on the four pillars that matter most for scrapyards.</p>
@@ -54,7 +54,7 @@ import { withBase } from "../lib/paths"
   <section class="band bg-brand-orange/5">
     <div class="section">
       <div class="reveal">
-        <div class="container-narrow">
+        <div class="content-narrow">
           <h2 class="text-2xl font-bold tracking-tight">Service Packages</h2>
     <div class="mt-6 grid gap-6 md:grid-cols-3">
       <div class="rounded-lg border border-zinc-200 p-6">

--- a/src/pages/terms-of-service.astro
+++ b/src/pages/terms-of-service.astro
@@ -8,7 +8,7 @@ import { withBase } from "../lib/paths"
   </Fragment>
   <section class="band">
     <div class="section">
-      <div class="container-narrow">
+      <div class="content-narrow">
         <h1 class="text-3xl font-bold tracking-tight">Terms of Service</h1>
       <section class="mt-6 prose prose-zinc max-w-none">
         <h2>Agreement</h2>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -30,6 +30,10 @@
 	.section-narrow {
 		@apply mx-auto max-w-3xl px-6 md:px-12 py-8 md:py-12;
 	}
+	/* Container for centering content within a section that already has padding */
+	.content-narrow {
+		@apply mx-auto max-w-3xl;
+	}
 	/* Mobile section padding - standardized 24px horizontal padding from viewport edges */
 	/* Note: Do not use with .container class as it already includes padding */
 	.mobile-section-padding {


### PR DESCRIPTION
Introduces a new `content-narrow` class and replaces nested `container-narrow` usages to fix double horizontal padding on mobile.

---
<a href="https://cursor.com/background-agent?bcId=bc-c7008bb3-d0ef-4fee-8e73-7accf96d4206">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c7008bb3-d0ef-4fee-8e73-7accf96d4206">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

