### PR TITLE
Fix horizontal padding on page elements

### DIFF
--- a/src/components/PricingTable.astro
+++ b/src/components/PricingTable.astro
@@ -15,7 +15,7 @@ const {
 	tinted = false,
 } = Astro.props as Props
 ---
-<div class="section">
+<div class="content-narrow">
   <div class="eyebrow">Pricing</div>
   <h2 class="mt-1 text-2xl font-bold tracking-tight">{heading}</h2>
   <div class="mt-6 grid gap-6 md:grid-cols-2">
@@ -44,5 +44,4 @@ const {
   )}
   
 </div>
-
 


### PR DESCRIPTION
Fixes double horizontal padding on pages by changing `PricingTable` component's root element to `content-narrow`.

The `PricingTable` component previously used the `.section` class internally, which applies horizontal padding. When this component was nested within another element that also had the `.section` class, it resulted in an unintended double application of horizontal padding, causing visual inconsistencies. Changing to `content-narrow` ensures that the component's internal container only centers content without adding redundant padding.

---
<a href="https://cursor.com/background-agent?bcId=bc-e3f36f31-3cf6-4f60-886c-1b24c3a59e28">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e3f36f31-3cf6-4f60-886c-1b24c3a59e28">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

