### PR TITLE
Fix incorrect horizontal page padding

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -19,25 +19,25 @@
 		@apply text-xs font-semibold uppercase tracking-wider text-zinc-700;
 	}
 	.container {
-		@apply mx-auto max-w-7xl px-6 md:px-12;
+		@apply mx-auto max-w-7xl px-6;
 	}
 	.container-narrow {
-		@apply mx-auto max-w-3xl px-6 md:px-12;
+		@apply mx-auto max-w-3xl px-6;
 	}
 	.section {
-		@apply mx-auto max-w-7xl px-6 md:px-12 py-12 md:py-16;
+		@apply mx-auto max-w-7xl px-6 py-12 md:py-16;
 	}
 	.section-narrow {
-		@apply mx-auto max-w-3xl px-6 md:px-12 py-8 md:py-12;
+		@apply mx-auto max-w-3xl px-6 py-8 md:py-12;
 	}
 	/* Container for centering content within a section that already has padding */
 	.content-narrow {
 		@apply mx-auto max-w-3xl;
 	}
-	/* Mobile section padding - standardized 24px horizontal padding from viewport edges */
+	/* Section padding - standardized 24px horizontal padding from viewport edges on all screen sizes */
 	/* Note: Do not use with .container class as it already includes padding */
 	.mobile-section-padding {
-		@apply px-6 md:px-12;
+		@apply px-6;
 	}
 	.anchor-target {
 		scroll-margin-top: 6rem;


### PR DESCRIPTION
Update global CSS classes to ensure consistent 24px horizontal padding across all screen sizes.

---
<a href="https://cursor.com/background-agent?bcId=bc-f78c5fb1-650c-471d-af21-88e8e0eeca5d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f78c5fb1-650c-471d-af21-88e8e0eeca5d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

