### PR TITLE
Fix incorrect horizontal padding on all pages

### DIFF
--- a/.astro/types.d.ts
+++ b/.astro/types.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="astro/client" />
+/// <reference path="content.d.ts" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -6573,16 +6573,17 @@
 			"license": "MIT"
 		},
 		"node_modules/prettier": {
-			"version": "2.8.7",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.7.tgz",
-			"integrity": "sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==",
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+			"integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"bin": {
-				"prettier": "bin-prettier.js"
+				"prettier": "bin/prettier.cjs"
 			},
 			"engines": {
-				"node": ">=10.13.0"
+				"node": ">=14"
 			},
 			"funding": {
 				"url": "https://github.com/prettier/prettier?sponsor=1"
@@ -9004,6 +9005,22 @@
 			},
 			"optionalDependencies": {
 				"prettier": "2.8.7"
+			}
+		},
+		"node_modules/yaml-language-server/node_modules/prettier": {
+			"version": "2.8.7",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.7.tgz",
+			"integrity": "sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==",
+			"license": "MIT",
+			"optional": true,
+			"bin": {
+				"prettier": "bin-prettier.js"
+			},
+			"engines": {
+				"node": ">=10.13.0"
+			},
+			"funding": {
+				"url": "https://github.com/prettier/prettier?sponsor=1"
 			}
 		},
 		"node_modules/yaml-language-server/node_modules/request-light": {

--- a/src/components/BetaInvite.astro
+++ b/src/components/BetaInvite.astro
@@ -1,7 +1,7 @@
 ---
 import { withBase } from "../lib/paths"
 ---
-<section class="mt-16">
+<section class="mt-16 px-6">
   <div class="container">
     <div class="rounded-lg bg-brand-orange text-white p-6 sm:p-8">
       <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">

--- a/src/components/DepositBanner.astro
+++ b/src/components/DepositBanner.astro
@@ -9,7 +9,7 @@ const {
 	sub = "50% today, balance at launch – 90-day warm lead guarantee",
 } = Astro.props as Props
 ---
-<section class="mt-16">
+<section class="mt-16 px-6">
   <div class="container">
     <div class="rounded-lg bg-brand-orange text-white p-6 sm:p-8">
       <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -6,7 +6,7 @@ const { tinted = false } = Astro.props as Props
 const year = new Date().getFullYear()
 import { withBase } from "../lib/paths"
 ---
-<footer class={"border-t border-zinc-200 " + (tinted ? "bg-brand-orange/5" : "bg-white")}>
+<footer class={"border-t border-zinc-200 px-6 " + (tinted ? "bg-brand-orange/5" : "bg-white")}>
   <div class="container py-12">
     <div class="flex flex-col gap-8 text-left">
       <div>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -5,7 +5,7 @@ const currentPath = Astro.url.pathname
 const calendlyUrl = import.meta.env.PUBLIC_CALENDLY_URL
 const ctaHref = calendlyUrl || withBase("/contact/")
 ---
-<header class="sticky top-0 z-50 bg-white shadow-header">
+<header class="sticky top-0 z-50 bg-white shadow-header px-6">
   <input id="nav-toggle" type="checkbox" class="peer sr-only" />
   <div class="container">
     <div class="flex h-16 items-center justify-between">

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -32,7 +32,7 @@ const resolvedSecondary = secondaryHref ? withBase(secondaryHref) : undefined
 ---
 <section class="relative isolate">
   <div
-    class="relative h-[65vh] min-h-[26.25rem] w-full bg-cover bg-center"
+    class="relative h-[65vh] min-h-[26.25rem] w-full bg-cover bg-center px-6"
     style={bgStyle}
     aria-hidden="true"
   >

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -3,9 +3,11 @@ import Base from "../layouts/Base.astro"
 import { withBase } from "../lib/paths"
 ---
 <Base title="Page not found — Scrapyard Sites">
-  <section class="container-narrow py-24 text-center">
-    <h1 class="text-4xl font-bold tracking-tight">404 — Page not found</h1>
-    <p class="mt-3 text-zinc-600">The page you’re looking for doesn’t exist or has moved.</p>
-    <a class="mt-6 inline-block link" href={withBase('/')}>Go home →</a>
+  <section class="px-6">
+    <div class="container-narrow py-24 text-center">
+      <h1 class="text-4xl font-bold tracking-tight">404 — Page not found</h1>
+      <p class="mt-3 text-zinc-600">The page you're looking for doesn't exist or has moved.</p>
+      <a class="mt-6 inline-block link" href={withBase('/')}>Go home →</a>
+    </div>
   </section>
 </Base>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -6,7 +6,8 @@ import { withBase } from "../../lib/paths"
   <Fragment slot="head">
     <meta name="description" content="Articles on credibility, qualification, visibility, and reliability for scrap yard owners." />
   </Fragment>
-  <section class="container py-16">
+  <section class="px-6">
+    <div class="container py-16">
     <div class="eyebrow">Blog</div>
     <h1 class="mt-1 text-3xl font-bold tracking-tight">Reputation & Growth Insights</h1>
     <p class="mt-3 max-w-2xl text-zinc-700">Practical articles on credibility, lead qualification, local visibility and operational reliability—written specifically for scrap yard owners.</p>
@@ -38,6 +39,7 @@ import { withBase } from "../../lib/paths"
         <p class="mt-1 text-sm text-zinc-600">Security patches, backups and monitoring keep your site running 24/7.</p>
         <div class="mt-2 text-sm"><span class="link">Read more →</span></div>
       </a>
+    </div>
     </div>
   </section>
 </Base>

--- a/src/pages/blog/posts/care-plan-essentials.astro
+++ b/src/pages/blog/posts/care-plan-essentials.astro
@@ -14,12 +14,14 @@ import { withBase } from "../../../lib/paths"
       mainEntityOfPage: { '@type': 'WebPage', '@id': Astro.url.href }
     })}</script>
   </Fragment>
-  <main class="container-narrow py-16">
+  <main class="px-6">
+    <div class="container-narrow py-16">
     <a href={withBase('/blog/')} class="link">← Back to blog</a>
     <div class="mt-6 text-xs font-semibold uppercase text-zinc-500">Reliability</div>
     <h1 class="mt-1 text-3xl font-bold tracking-tight">Care Plan Essentials</h1>
     <div class="mt-1 text-sm text-zinc-600">By Scrapyard Sites | January 3, 2024</div>
     <p class="mt-6">Regular security patches and backups keep your website running smoothly around the clock.</p>
+    </div>
   </main>
 </Base>
 

--- a/src/pages/blog/posts/pre-qualify-scrap-sellers.astro
+++ b/src/pages/blog/posts/pre-qualify-scrap-sellers.astro
@@ -14,12 +14,14 @@ import { withBase } from "../../../lib/paths"
       mainEntityOfPage: { '@type': 'WebPage', '@id': Astro.url.href }
     })}</script>
   </Fragment>
-  <main class="container-narrow py-16">
+  <main class="px-6">
+    <div class="container-narrow py-16">
     <a href={withBase('/blog/')} class="link">← Back to blog</a>
     <div class="mt-6 text-xs font-semibold uppercase text-zinc-500">Qualification</div>
     <h1 class="mt-1 text-3xl font-bold tracking-tight">Pre‑Qualify Scrap Sellers</h1>
     <div class="mt-1 text-sm text-zinc-600">By Scrapyard Sites | January 2, 2024</div>
     <p class="mt-6">Use detailed intake forms to screen leads so you only spend time on serious sellers.</p>
+    </div>
   </main>
 </Base>
 

--- a/src/pages/blog/posts/seo-basics-for-scrap-yards.astro
+++ b/src/pages/blog/posts/seo-basics-for-scrap-yards.astro
@@ -14,12 +14,14 @@ import { withBase } from "../../../lib/paths"
       mainEntityOfPage: { '@type': 'WebPage', '@id': Astro.url.href }
     })}</script>
   </Fragment>
-  <main class="container-narrow py-16">
+  <main class="px-6">
+    <div class="container-narrow py-16">
     <a href={withBase('/blog/')} class="link">← Back to blog</a>
     <div class="mt-6 text-xs font-semibold uppercase text-zinc-500">Visibility</div>
     <h1 class="mt-1 text-3xl font-bold tracking-tight">SEO Basics for Scrap Yards</h1>
     <div class="mt-1 text-sm text-zinc-600">By Scrapyard Sites | January 1, 2024</div>
     <p class="mt-6">Effective SEO begins with optimizing your local listings and using structured data so search engines understand your business.</p>
+    </div>
   </main>
 </Base>
 

--- a/src/pages/privacy/index.astro
+++ b/src/pages/privacy/index.astro
@@ -5,7 +5,8 @@ import Base from "../../layouts/Base.astro"
   <Fragment slot="head">
     <meta name="description" content="Learn how Scrapyard Sites collects, uses, and protects your information." />
   </Fragment>
-  <main class="container-narrow py-16">
+  <main class="px-6">
+    <div class="container-narrow py-16">
     <h1 class="text-3xl font-bold tracking-tight">Privacy Policy</h1>
     <p class="mt-4 text-sm text-zinc-700">Effective Date: January 1, 2024</p>
     <section class="mt-6 prose prose-zinc max-w-none">
@@ -30,6 +31,7 @@ import Base from "../../layouts/Base.astro"
       <h2>Contact</h2>
       <p>Email: <a href="mailto:hello@scrapyardsites.com">hello@scrapyardsites.com</a> | Phone: <a href="tel:19493568762">949‑356‑8762</a></p>
     </section>
+    </div>
   </main>
 </Base>
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -19,16 +19,16 @@
 		@apply text-xs font-semibold uppercase tracking-wider text-zinc-700;
 	}
 	.container {
-		@apply mx-auto max-w-7xl px-6;
+		@apply mx-auto max-w-7xl;
 	}
 	.container-narrow {
-		@apply mx-auto max-w-3xl px-6;
+		@apply mx-auto max-w-3xl;
 	}
 	.section {
-		@apply mx-auto max-w-7xl px-6 py-12 md:py-16;
+		@apply mx-auto max-w-7xl py-12 md:py-16;
 	}
 	.section-narrow {
-		@apply mx-auto max-w-3xl px-6 py-8 md:py-12;
+		@apply mx-auto max-w-3xl py-8 md:py-12;
 	}
 	/* Container for centering content within a section that already has padding */
 	.content-narrow {
@@ -61,7 +61,7 @@
 
 	/* Banded section separator */
 	.band {
-		@apply border-y border-zinc-100;
+		@apply border-y border-zinc-100 px-6;
 	}
 
 	/* Chips */


### PR DESCRIPTION
Adjust horizontal padding application to ensure consistent 24px spacing from viewport edges.

Previously, `px-6` padding was applied to `max-w-*` container classes, causing content to be centered but the padding to only appear within the container, not from the viewport edge. This PR shifts the padding to outer wrapper elements (like `.band` or direct section/component wrappers) to achieve consistent 24px spacing from the viewport.

---
<a href="https://cursor.com/background-agent?bcId=bc-154eb3dd-bd94-4676-a65a-9df54fdd79a7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-154eb3dd-bd94-4676-a65a-9df54fdd79a7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

