### PR TITLE
Fix incorrect horizontal padding on all pages

### DIFF
--- a/src/components/BetaInvite.astro
+++ b/src/components/BetaInvite.astro
@@ -1,7 +1,7 @@
 ---
 import { withBase } from "../lib/paths"
 ---
-<section class="mt-16 px-6">
+<section class="mt-16">
   <div class="container">
     <div class="rounded-lg bg-brand-orange text-white p-6 sm:p-8">
       <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">

--- a/src/components/DepositBanner.astro
+++ b/src/components/DepositBanner.astro
@@ -9,7 +9,7 @@ const {
 	sub = "50% today, balance at launch – 90-day warm lead guarantee",
 } = Astro.props as Props
 ---
-<section class="mt-16 px-6">
+<section class="mt-16">
   <div class="container">
     <div class="rounded-lg bg-brand-orange text-white p-6 sm:p-8">
       <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -6,7 +6,7 @@ const { tinted = false } = Astro.props as Props
 const year = new Date().getFullYear()
 import { withBase } from "../lib/paths"
 ---
-<footer class={"border-t border-zinc-200 px-6 " + (tinted ? "bg-brand-orange/5" : "bg-white")}>
+<footer class={"border-t border-zinc-200 " + (tinted ? "bg-brand-orange/5" : "bg-white")}>
   <div class="container py-12">
     <div class="flex flex-col gap-8 text-left">
       <div>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -5,7 +5,7 @@ const currentPath = Astro.url.pathname
 const calendlyUrl = import.meta.env.PUBLIC_CALENDLY_URL
 const ctaHref = calendlyUrl || withBase("/contact/")
 ---
-<header class="sticky top-0 z-50 bg-white shadow-header px-6">
+<header class="sticky top-0 z-50 bg-white shadow-header">
   <input id="nav-toggle" type="checkbox" class="peer sr-only" />
   <div class="container">
     <div class="flex h-16 items-center justify-between">

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -32,7 +32,7 @@ const resolvedSecondary = secondaryHref ? withBase(secondaryHref) : undefined
 ---
 <section class="relative isolate">
   <div
-    class="relative h-[65vh] min-h-[26.25rem] w-full bg-cover bg-center px-6"
+    class="relative h-[65vh] min-h-[26.25rem] w-full bg-cover bg-center"
     style={bgStyle}
     aria-hidden="true"
   >

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -3,7 +3,7 @@ import Base from "../layouts/Base.astro"
 import { withBase } from "../lib/paths"
 ---
 <Base title="Page not found — Scrapyard Sites">
-  <section class="px-6">
+  <section>
     <div class="container-narrow py-24 text-center">
       <h1 class="text-4xl font-bold tracking-tight">404 — Page not found</h1>
       <p class="mt-3 text-zinc-600">The page you're looking for doesn't exist or has moved.</p>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -6,7 +6,7 @@ import { withBase } from "../../lib/paths"
   <Fragment slot="head">
     <meta name="description" content="Articles on credibility, qualification, visibility, and reliability for scrap yard owners." />
   </Fragment>
-  <section class="px-6">
+  <section>
     <div class="container py-16">
     <div class="eyebrow">Blog</div>
     <h1 class="mt-1 text-3xl font-bold tracking-tight">Reputation & Growth Insights</h1>

--- a/src/pages/blog/posts/care-plan-essentials.astro
+++ b/src/pages/blog/posts/care-plan-essentials.astro
@@ -14,7 +14,7 @@ import { withBase } from "../../../lib/paths"
       mainEntityOfPage: { '@type': 'WebPage', '@id': Astro.url.href }
     })}</script>
   </Fragment>
-  <main class="px-6">
+  <main>
     <div class="container-narrow py-16">
     <a href={withBase('/blog/')} class="link">← Back to blog</a>
     <div class="mt-6 text-xs font-semibold uppercase text-zinc-500">Reliability</div>

--- a/src/pages/blog/posts/pre-qualify-scrap-sellers.astro
+++ b/src/pages/blog/posts/pre-qualify-scrap-sellers.astro
@@ -14,7 +14,7 @@ import { withBase } from "../../../lib/paths"
       mainEntityOfPage: { '@type': 'WebPage', '@id': Astro.url.href }
     })}</script>
   </Fragment>
-  <main class="px-6">
+  <main>
     <div class="container-narrow py-16">
     <a href={withBase('/blog/')} class="link">← Back to blog</a>
     <div class="mt-6 text-xs font-semibold uppercase text-zinc-500">Qualification</div>

--- a/src/pages/blog/posts/seo-basics-for-scrap-yards.astro
+++ b/src/pages/blog/posts/seo-basics-for-scrap-yards.astro
@@ -14,7 +14,7 @@ import { withBase } from "../../../lib/paths"
       mainEntityOfPage: { '@type': 'WebPage', '@id': Astro.url.href }
     })}</script>
   </Fragment>
-  <main class="px-6">
+  <main>
     <div class="container-narrow py-16">
     <a href={withBase('/blog/')} class="link">← Back to blog</a>
     <div class="mt-6 text-xs font-semibold uppercase text-zinc-500">Visibility</div>

--- a/src/pages/privacy/index.astro
+++ b/src/pages/privacy/index.astro
@@ -5,7 +5,7 @@ import Base from "../../layouts/Base.astro"
   <Fragment slot="head">
     <meta name="description" content="Learn how Scrapyard Sites collects, uses, and protects your information." />
   </Fragment>
-  <main class="px-6">
+  <main>
     <div class="container-narrow py-16">
     <h1 class="text-3xl font-bold tracking-tight">Privacy Policy</h1>
     <p class="mt-4 text-sm text-zinc-700">Effective Date: January 1, 2024</p>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -22,13 +22,13 @@
 		@apply mx-auto max-w-7xl;
 	}
 	.container-narrow {
-		@apply mx-auto max-w-3xl;
+		@apply mx-auto max-w-3xl px-6;
 	}
 	.section {
-		@apply mx-auto max-w-7xl py-12 md:py-16;
+		@apply mx-auto max-w-7xl px-6 py-12 md:py-16;
 	}
 	.section-narrow {
-		@apply mx-auto max-w-3xl py-8 md:py-12;
+		@apply mx-auto max-w-3xl px-6 py-8 md:py-12;
 	}
 	/* Container for centering content within a section that already has padding */
 	.content-narrow {
@@ -61,7 +61,7 @@
 
 	/* Banded section separator */
 	.band {
-		@apply border-y border-zinc-100 px-6;
+		@apply border-y border-zinc-100;
 	}
 
 	/* Chips */

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -13,6 +13,10 @@ export default {
 		"hamburger-line",
 	],
 	theme: {
+		container: {
+			center: true,
+			padding: "1.5rem", // 24px
+		},
 		extend: {
 			fontFamily: {
 				sans: [


### PR DESCRIPTION
Fixes incorrect horizontal padding by removing redundant `px-6` classes and configuring Tailwind's container to handle padding.

The issue stemmed from double padding: `px-6` was applied directly to many outer section/component elements, while nested `.container` classes also added their own default horizontal padding. This resulted in content being pushed too far from the viewport edges. The solution configures Tailwind's container to apply the desired 24px padding, then removes the redundant `px-6` classes from individual components and global CSS definitions.

---
<a href="https://cursor.com/background-agent?bcId=bc-6c0ed80d-c60c-43aa-a51b-522b8b145dd4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6c0ed80d-c60c-43aa-a51b-522b8b145dd4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

