### PR TITLE
Check code with biome

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -253,8 +253,8 @@
 		display: grid;
 		grid-template-rows: 0fr;
 		opacity: 0;
-		transition: grid-template-rows 0.35s cubic-bezier(0.4, 0, 0.2, 1), 
-			opacity 0.35s cubic-bezier(0.4, 0, 0.2, 1);
+		transition: grid-template-rows 0.35s cubic-bezier(0.4, 0, 0.2, 1), opacity
+			0.35s cubic-bezier(0.4, 0, 0.2, 1);
 	}
 	.faq-details[open] .faq-content {
 		grid-template-rows: 1fr;


### PR DESCRIPTION
Fix Biome formatting error in `globals.css` by adjusting line break in `transition` property.

---
<a href="https://cursor.com/background-agent?bcId=bc-e2d044ec-878a-48c3-9bd7-7e74b5f1d334">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e2d044ec-878a-48c3-9bd7-7e74b5f1d334">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

