### PR TITLE
Fix faq animation snapping on close

### DIFF
--- a/src/components/FAQ.astro
+++ b/src/components/FAQ.astro
@@ -26,7 +26,7 @@ const detailsClass = tinted
       <details class={detailsClass} itemscope itemprop="mainEntity" itemtype="https://schema.org/Question">
         <summary class="font-medium flex items-center justify-between text-left w-full cursor-pointer" itemprop="name">
           <span>{it.q}</span>
-          <svg class="faq-chevron h-5 w-5 flex-shrink-0 transition-transform duration-[350ms] cubic-bezier(0.4, 0, 0.2, 1)" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <svg class="faq-chevron h-5 w-5 flex-shrink-0 transition-transform duration-300 cubic-bezier(0.4, 0, 0.2, 1)" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
           </svg>
         </summary>
@@ -48,12 +48,14 @@ const detailsClass = tinted
       const chevron = details.querySelector('.faq-chevron');
       
       details.addEventListener('toggle', function(e) {
-        // Smooth chevron rotation
-        if (details.open) {
-          chevron.style.transform = 'rotate(180deg)';
-        } else {
-          chevron.style.transform = 'rotate(0deg)';
-        }
+        // Smooth chevron rotation with proper timing
+        requestAnimationFrame(() => {
+          if (details.open) {
+            chevron.style.transform = 'rotate(180deg)';
+          } else {
+            chevron.style.transform = 'rotate(0deg)';
+          }
+        });
       });
     });
   });

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -248,22 +248,21 @@
 		user-select: none;
 	}
 
-	/* Smooth drawer animation using grid */
+	/* Smooth drawer animation using max-height */
 	.faq-content {
-		display: grid;
-		grid-template-rows: 0fr;
+		max-height: 0;
 		opacity: 0;
-		transition: grid-template-rows 0.35s cubic-bezier(0.4, 0, 0.2, 1), opacity
-			0.35s cubic-bezier(0.4, 0, 0.2, 1);
+		overflow: hidden;
+		transition: max-height 0.3s cubic-bezier(0.4, 0, 0.2, 1), 
+		           opacity 0.25s cubic-bezier(0.4, 0, 0.2, 1);
 	}
 	.faq-details[open] .faq-content {
-		grid-template-rows: 1fr;
+		max-height: 200px; /* Reasonable max height for FAQ content */
 		opacity: 1;
 	}
 	.faq-content > div {
-		overflow: hidden;
 		transform: translateY(-4px);
-		transition: transform 0.35s cubic-bezier(0.4, 0, 0.2, 1);
+		transition: transform 0.25s cubic-bezier(0.4, 0, 0.2, 1) 0.05s; /* Slight delay */
 	}
 	.faq-details[open] .faq-content > div {
 		transform: translateY(0);


### PR DESCRIPTION
Refactor FAQ animation to use `max-height` for smoother closing, resolving snapping behavior caused by `grid-template-rows`.

---
<a href="https://cursor.com/background-agent?bcId=bc-e36e7d51-6f55-4211-a8e9-4ac4d0f013b5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e36e7d51-6f55-4211-a8e9-4ac4d0f013b5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

