### PR TITLE
Apply viewport padding across site sections

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -38,7 +38,7 @@ const resolvedSecondary = secondaryHref ? withBase(secondaryHref) : undefined
   >
     <img src={bgSrc} alt="" class="absolute inset-0 h-full w-full object-cover" loading="eager" />
     <div class="absolute inset-0 bg-black/80"></div>
-    <div class="relative z-10 container hero-container py-24 flex h-full items-center">
+    <div class="relative z-10 container py-24 flex h-full items-center">
       <div class="text-white max-w-4xl">
         <h1 class="text-3xl sm:text-4xl md:text-5xl font-bold tracking-tight">{title}</h1>
         {body && <p class="mt-4 text-base sm:text-lg text-zinc-100">{body}</p>}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -7,7 +7,7 @@
 	html {
 		scroll-behavior: smooth;
 	}
-	
+
 	/* Prevent scroll when menu is open */
 	body.menu-open {
 		overflow: hidden !important;
@@ -25,26 +25,27 @@
 	.eyebrow {
 		@apply text-xs font-semibold uppercase tracking-wider text-zinc-700;
 	}
+	/* Container classes with responsive viewport padding */
 	.container {
-		@apply mx-auto max-w-7xl px-9;
+		@apply mx-auto max-w-7xl px-viewport-mobile sm:px-viewport-mobile md:px-viewport-tablet lg:px-viewport-desktop;
 	}
 	.container-narrow {
-		@apply mx-auto max-w-3xl px-9;
+		@apply mx-auto max-w-3xl px-viewport-mobile sm:px-viewport-mobile md:px-viewport-tablet lg:px-viewport-desktop;
 	}
 	.section {
-		@apply mx-auto max-w-7xl px-9 py-12 md:py-16;
+		@apply mx-auto max-w-7xl px-viewport-mobile sm:px-viewport-mobile md:px-viewport-tablet lg:px-viewport-desktop py-12 md:py-16;
 	}
 	.section-narrow {
-		@apply mx-auto max-w-3xl px-9 py-8 md:py-12;
+		@apply mx-auto max-w-3xl px-viewport-mobile sm:px-viewport-mobile md:px-viewport-tablet lg:px-viewport-desktop py-8 md:py-12;
 	}
 	/* Container for centering content within a section that already has padding */
 	.content-narrow {
 		@apply mx-auto max-w-3xl;
 	}
-	/* Section padding - standardized 36px horizontal padding from viewport edges on all screen sizes */
+	/* Section padding - responsive horizontal padding from viewport edges */
 	/* Note: Do not use with .container class as it already includes padding */
-	.mobile-section-padding {
-		@apply px-9;
+	.viewport-padding {
+		@apply px-viewport-mobile sm:px-viewport-mobile md:px-viewport-tablet lg:px-viewport-desktop;
 	}
 	.anchor-target {
 		scroll-margin-top: 6rem;
@@ -77,12 +78,7 @@
 	}
 
 	/* Component-specific padding overrides */
-	/* Hero, Header, Footer, and FAQ maintain 24px padding */
-	header .container,
-	footer .container,
-	.hero-container {
-		@apply px-6;
-	}
+	/* All components now use responsive viewport padding */
 
 	/* Buttons */
 	.btn {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -15,7 +15,17 @@ export default {
 	theme: {
 		container: {
 			center: true,
-			padding: "1.5rem", // 24px
+			padding: {
+				DEFAULT: "2.25rem", // 36px for mobile
+				sm: "2.25rem", // 36px for mobile (larger)
+				md: "4rem", // 64px for tablet
+				lg: "8rem", // 128px for desktop
+			},
+			screens: {
+				sm: "412px",
+				md: "768px",
+				lg: "1200px",
+			},
 		},
 		extend: {
 			fontFamily: {
@@ -43,6 +53,15 @@ export default {
 			},
 			boxShadow: {
 				header: "0 1px 2px rgba(0,0,0,0.06), 0 2px 8px rgba(0,0,0,0.04)",
+			},
+			spacing: {
+				"viewport-mobile": "2.25rem", // 36px
+				"viewport-tablet": "4rem", // 64px
+				"viewport-desktop": "8rem", // 128px
+			},
+			screens: {
+				"mobile-sm": "360px",
+				"mobile-lg": "412px",
 			},
 		},
 	},


### PR DESCRIPTION
Implement a responsive viewport padding schema across the site.

This PR updates Tailwind's container configuration and global CSS classes to apply device-specific left/right padding. It also removes previous component-specific padding overrides to ensure consistency, excluding the navigation bar as requested.

---
<a href="https://cursor.com/background-agent?bcId=bc-9dbb4444-41ee-4c84-9983-121ce9ec1f73">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9dbb4444-41ee-4c84-9983-121ce9ec1f73">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

