### PR TITLE
Run pnpm lint to check code formatting

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -256,14 +256,14 @@
 		max-height: 0;
 		opacity: 0;
 		overflow: hidden;
-		transition: max-height 0.6s cubic-bezier(0.25, 0.46, 0.45, 0.94), 
-		            opacity 0.5s cubic-bezier(0.25, 0.46, 0.45, 0.94) 0.1s;
+		transition: max-height 0.6s cubic-bezier(0.25, 0.46, 0.45, 0.94), opacity
+			0.5s cubic-bezier(0.25, 0.46, 0.45, 0.94) 0.1s;
 	}
 	.faq-details[open] .faq-content {
 		max-height: 500px;
 		opacity: 1;
-		transition: max-height 0.6s cubic-bezier(0.25, 0.46, 0.45, 0.94), 
-		            opacity 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94) 0.1s;
+		transition: max-height 0.6s cubic-bezier(0.25, 0.46, 0.45, 0.94), opacity
+			0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94) 0.1s;
 	}
 	.faq-content > div {
 		transform: translateY(-8px);


### PR DESCRIPTION
Reformat CSS transition properties to resolve Biome linting errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-f91c28ef-b33b-4138-b639-9d72e3c3d3e5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f91c28ef-b33b-4138-b639-9d72e3c3d3e5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

