### PR TITLE
Fix hamburger and faq animation issues

### DIFF
--- a/src/components/FAQ.astro
+++ b/src/components/FAQ.astro
@@ -67,21 +67,12 @@ const detailsClass = tinted
         
         // Toggle the open state
         if (detail.hasAttribute('open')) {
-          // Closing animation
-          detail.style.overflow = 'hidden';
-          requestAnimationFrame(() => {
-            detail.removeAttribute('open');
-            setTimeout(() => {
-              detail.style.overflow = '';
-            }, 300);
-          });
+          // Closing animation - don't use overflow hidden as it causes snapping
+          // The CSS grid animation handles the smooth transition
+          detail.removeAttribute('open');
         } else {
           // Opening animation
           detail.setAttribute('open', '');
-          detail.style.overflow = 'hidden';
-          setTimeout(() => {
-            detail.style.overflow = '';
-          }, 300);
         }
       });
     });

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -48,8 +48,8 @@ const ctaHref = calendlyUrl || withBase("/contact/")
       <a href={withBase('/about/')} aria-current={currentPath.startsWith(withBase('/about/')) ? 'page' : undefined} class={`mobile-nav-item block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-orange rounded-sm ${currentPath.startsWith(withBase('/about/')) ? 'text-brand-orange' : ''}`}>About</a>
       <a href={withBase('/contact/')} aria-current={currentPath.startsWith(withBase('/contact/')) ? 'page' : undefined} class={`mobile-nav-item block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-orange rounded-sm ${currentPath.startsWith(withBase('/contact/')) ? 'text-brand-orange' : ''}`}>Contact</a>
     </nav>
-    <div class="p-8 border-t border-zinc-100" style="padding-bottom: max(2rem, env(safe-area-inset-bottom, 0) + 1rem); margin-bottom: env(safe-area-inset-bottom, 0);">
-      <a href={ctaHref} class="btn btn-primary w-full px-4 py-3" style="margin-bottom: env(safe-area-inset-bottom, 0);">
+    <div class="p-8 border-t border-zinc-100" style="padding-bottom: max(2rem, env(safe-area-inset-bottom, 0));">
+      <a href={ctaHref} class="btn btn-primary w-full px-4 py-3">
         Book a 15-minute call
       </a>
     </div>
@@ -81,13 +81,8 @@ const ctaHref = calendlyUrl || withBase("/contact/")
         document.body.style.width = '';
         document.body.style.overflow = '';
         
-        // Restore scroll position smoothly without causing scroll events
-        if (scrollPosition > 0) {
-          window.scrollTo({
-            top: scrollPosition,
-            behavior: 'instant'
-          });
-        }
+        // Restore scroll position without animation to prevent jumping
+        window.scrollTo(0, scrollPosition);
       }
       
       // Handle menu-open class immediately for hamburger animation

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -258,7 +258,7 @@
 		display: grid;
 		grid-template-rows: 0fr;
 		opacity: 0;
-		transition: grid-template-rows 0.3s ease-out, opacity 0.3s ease-out;
+		transition: grid-template-rows 0.3s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 	}
 	.faq-details[open] .faq-content {
 		grid-template-rows: 1fr;
@@ -267,7 +267,7 @@
 	.faq-content > div {
 		overflow: hidden;
 		transform: translateY(-4px);
-		transition: transform 0.3s ease-out;
+		transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 	}
 	.faq-details[open] .faq-content > div {
 		transform: translateY(0);
@@ -299,8 +299,7 @@
 		flex-direction: column;
 		/* Background is here, not on overlay */
 		background-color: white;
-		/* Account for iOS Safari bottom bar */
-		padding-bottom: env(safe-area-inset-bottom, 0);
+		/* Remove padding-bottom here as it's handled in the HTML */
 	}
 
 	.mobile-menu-overlay.menu-open .menu-content {


### PR DESCRIPTION
Fixes hamburger menu CTA visibility and scroll restoration, and smooths FAQ close animation.

The hamburger menu's CTA was hidden in Safari due to incorrect safe area padding and margin, and the scroll position reset on close due to `window.scrollTo` behavior. The FAQ animation was snapping on close because JavaScript was prematurely manipulating `overflow: hidden`, which is now handled purely by CSS `grid-template-rows` transitions with an improved easing function.

---
<a href="https://cursor.com/background-agent?bcId=bc-eda05968-9092-4d45-9c2a-fa2be4dfda2c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-eda05968-9092-4d45-9c2a-fa2be4dfda2c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

