### PR TITLE
Run biome check and fix errors

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -258,7 +258,8 @@
 		display: grid;
 		grid-template-rows: 0fr;
 		opacity: 0;
-		transition: grid-template-rows 0.3s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+		transition: grid-template-rows 0.3s cubic-bezier(0.4, 0, 0.2, 1), opacity
+			0.3s cubic-bezier(0.4, 0, 0.2, 1);
 	}
 	.faq-details[open] .faq-content {
 		grid-template-rows: 1fr;


### PR DESCRIPTION
Fix Biome linting error by reformatting a long CSS transition property.

---
<a href="https://cursor.com/background-agent?bcId=bc-8a522df0-daf2-4ee4-aa2d-862e96256246">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8a522df0-daf2-4ee4-aa2d-862e96256246">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

