### PR TITLE
Adjust hamburger menu cta safari viewport

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -41,7 +41,7 @@ const ctaHref = calendlyUrl || withBase("/contact/")
 </header>
 
 <div id="mobile-nav" class="mobile-menu-overlay fixed inset-0" style="padding-top: 4rem; z-index: 45;" role="dialog" aria-modal="true" aria-label="Site Navigation">
-  <div class="menu-content shadow-md flex flex-col" style="position: relative; z-index: 46; height: calc(100% - 4rem);">
+  <div class="menu-content shadow-md flex flex-col" style="position: relative; z-index: 46; height: calc(100% - 4rem - env(safe-area-inset-bottom, 0));">
     <nav class="flex-1 overflow-y-auto p-6 text-lg font-medium space-y-5" aria-label="Mobile Navigation">
       <a href={withBase('/')} aria-current={currentPath === withBase('/')} class={`mobile-nav-item block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-orange rounded-sm ${currentPath === withBase('/') ? 'text-brand-orange' : ''}`}>Home</a>
       <a href={withBase('/pricing/')} aria-current={currentPath.startsWith(withBase('/pricing/')) ? 'page' : undefined} class={`mobile-nav-item block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-orange rounded-sm ${currentPath.startsWith(withBase('/pricing/')) ? 'text-brand-orange' : ''}`}>Pricing</a>


### PR DESCRIPTION
Adjust mobile menu height calculation to account for Safari's safe area, preventing CTA button cutoff.

---
<a href="https://cursor.com/background-agent?bcId=bc-7e592074-d42e-45d2-b4bb-592390496614">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7e592074-d42e-45d2-b4bb-592390496614">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

